### PR TITLE
Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ See the [API Documentation](https://deltablot.github.io/malle/api) for usage and
 
 ## Contributing
 
-See [contributing documentation](./CONTRIBUTING.md).
+See [contributing documentation](https://github.com/deltablot/malle/blob/master/CONTRIBUTING.md).
 
 ## License
 
-This software is open source and licensed under the [MIT License](./LICENSE).
+This software is open source and licensed under the [MIT License](https://github.com/deltablot/malle/blob/master/LICENSE).


### PR DESCRIPTION
Replaced the relative links with absolute ones, in order to make they work also on the [API documentation page](https://deltablot.github.io/malle/api/#md:contributing).